### PR TITLE
Adds switch to dashboard for sulphur

### DIFF
--- a/data/index.html
+++ b/data/index.html
@@ -127,8 +127,8 @@ description: This is a sample beta site for Federal natural resource revenues.
         <input class="other commodity" type="checkbox" name="commodity" value="Sodium" id="chk-Sodium" checked />
         <div class="checkbox"></div>
       </label>
-      <label class="label-switch" for="chk-Sulphur">Sulphur
-        <input class="other commodity" type="checkbox" name="commodity" value="Sulphur" id="chk-Sulphur" checked />
+      <label class="label-switch" for="chk-Sulfur">Sulfur
+        <input class="other commodity" type="checkbox" name="commodity" value="Sulfur" id="chk-Sulfur" checked />
         <div class="checkbox"></div>
       </label>
     </div>


### PR DESCRIPTION
For #94 , but turning off everything _except_ sulphur does not show any data. Either I implemented wrong, or there isn't actually any revenue from sulphur in that dataset??
