### PR TITLE
Fix site under HTTPS

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -6,10 +6,10 @@ owner:
   twitter: DOIONRR
   facebook: DOIONRR
   # For Google Authorship https://plus.google.com/authorship
-  google_plus: 
+  google_plus:
 
-google_analytics:   
-google_verify:  
+google_analytics:
+google_verify:
 
 sass:
   sass_dir: static/_sass
@@ -18,11 +18,9 @@ markdown: kramdown
 highlighter: pygments
 
 baseurl: /doi-extractives-data
-url: http://18f.github.io/doi-extractives-data/
 
-# uncomment when working locally
-
-#url:  http://localhost:4000/
+# only use when absolute URL is absolutely necessary
+url: https://18f.github.io/doi-extractives-data
 
 kramdown:
   parse_block_html: true

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,7 +1,7 @@
 <footer class="section blue footer" role="contentinfo" itemscope itemtype="http://schema.org/WPFooter" data-target="footer">
   <div class="container">
     <ul>
-      <img src="{{ site.url }}static/img/U_S__Department_of_the_Interior.gif" alt="U.S. Department of the Interior Logo">
+      <img src="{{ site.url }}/static/img/U_S__Department_of_the_Interior.gif" alt="U.S. Department of the Interior Logo">
       <li><a href="http://www.doi.gov" itemprop="url">Department of the Interior</a></li>
       <li><a href="http://www.onrr.gov" itemprop="url">Office of Natural Resources Revenue</a></li>
     </ul>

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,5 +1,5 @@
 <head>
-	
+
 	<!-- Basic  Page Needs
 	================================================== -->
 	<meta charset="utf-8">
@@ -79,13 +79,13 @@
 	<!-- Helpers -->
 	<script src="{{ site.baseurl }}/static/js/helpers.js"></script>
 
-	<!-- ######CHECK ON IE9/jquery STUFF BELOW, NOT UPDATED FROM NOTALONE####### 
+	<!-- ######CHECK ON IE9/jquery STUFF BELOW, NOT UPDATED FROM NOTALONE#######
 	<script src="{{ site.baseurl }}/static/js/min/iecors.min.js"></script> -->
 	<!--[if lte IE 9]>
 	<script type='text/javascript' src='//cdnjs.cloudflare.com/ajax/libs/jquery-ajaxtransport-xdomainrequest/1.0.0/jquery.xdomainrequest.min.js'></script>
 	<![endif]-->
 
-	<!-- <script src="{{ site.url }}static/js/where.js"></script> -->
+	<!-- <script src="{{ site.baseurl }}/static/js/where.js"></script> -->
 
 	<!-- For Mapbox
 	================================================== -->
@@ -96,28 +96,28 @@
 	<!-- Favicons
 	================================================== -->
 	<!-- 16x16 and 32x32-->
-	<link rel="shortcut icon" href="{{ site.url }}/favicon.ico">
+	<link rel="shortcut icon" href="{{ site.baseurl }}/favicon.ico">
 
 	<!-- For IE 10 Metro tile icon -->
 	<meta name="msapplication-TileColor" content="#FFFFFF">
-	<meta name="msapplication-TileImage" content="{{ site.url }}/static/img/favicon/favicon-144.png">
+	<meta name="msapplication-TileImage" content="{{ site.baseurl }}/static/img/favicon/favicon-144.png">
 
 	<!-- For iPad with high-resolution Retina display running iOS ≥ 7: -->
-	<link rel="apple-touch-icon-precomposed" sizes="152x152" href="{{ site.url }}/static/img/favicon/favicon-152.png">
+	<link rel="apple-touch-icon-precomposed" sizes="152x152" href="{{ site.baseurl }}/static/img/favicon/favicon-152.png">
 
 	<!-- For iPad with high-resolution Retina display running iOS ≤ 6: -->
-	<link rel="apple-touch-icon-precomposed" sizes="144x144" href="{{ site.url }}/static/img/favicon/favicon-144.png">
+	<link rel="apple-touch-icon-precomposed" sizes="144x144" href="{{ site.baseurl }}/static/img/favicon/favicon-144.png">
 
 	<!-- For iPhone with high-resolution Retina display running iOS ≥ 7: -->
-	<link rel="apple-touch-icon-precomposed" sizes="120x120" href="{{ site.url }}/static/img/favicon/favicon-120.png">
+	<link rel="apple-touch-icon-precomposed" sizes="120x120" href="{{ site.baseurl }}/static/img/favicon/favicon-120.png">
 
 	<!-- For iPhone with high-resolution Retina display running iOS ≤ 6: -->
-	<link rel="apple-touch-icon-precomposed" sizes="114x114" href="{{ site.url }}/static/img/favicon/favicon-114.png">
+	<link rel="apple-touch-icon-precomposed" sizes="114x114" href="{{ site.baseurl }}/static/img/favicon/favicon-114.png">
 
 	<!-- For first- and second-generation iPad: -->
-	<link rel="apple-touch-icon-precomposed" sizes="72x72" href="{{ site.url }}/static/img/favicon/favicon-72.png">
+	<link rel="apple-touch-icon-precomposed" sizes="72x72" href="{{ site.baseurl }}/static/img/favicon/favicon-72.png">
 
 	<!-- For non-Retina iPhone, iPod Touch, and Android 2.1+ devices: -->
-	<link rel="apple-touch-icon-precomposed" href="{{ site.url }}/static/img/favicon/favicon-57.png">
+	<link rel="apple-touch-icon-precomposed" href="{{ site.baseurl }}/static/img/favicon/favicon-57.png">
 
 </head>

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -2,7 +2,7 @@
   <a id="nav-toggle" href="#"><span></span></a>
   <div class="container">
     <ul class="menu">
-    <a href="{{ site.url }}" itemprop="url" {% if page.title == "Home" %}class="active" {% endif %}>
+    <a href="{{ site.baseurl }}" itemprop="url" {% if page.title == "Home" %}class="active" {% endif %}>
     	<li itemprop="name">Home</li>
     </a>
     <a href="{{ site.baseurl }}/about/" itemprop="url" {% if page.title == "About" %}class="active" {% endif %}>
@@ -22,7 +22,7 @@
                 <input type="submit" value="&#10095;">
             </div>
         </form>
-    </li> 
+    </li>
     </ul>
   </div>
 </nav>

--- a/_includes/section-break.html
+++ b/_includes/section-break.html
@@ -1,3 +1,3 @@
 <section class="section break">
-  <img class="down" src="{{ site.url }}static/img/scroll-down.png" alt="You should scroll down. There is more to learn!">
+  <img class="down" src="{{ site.baseurl }}static/img/scroll-down.png" alt="You should scroll down. There is more to learn!">
 </section>

--- a/_includes/usa-bug.html
+++ b/_includes/usa-bug.html
@@ -1,7 +1,7 @@
 <aside class="usa">
   <div class="container">
     <p>
-      An official website of the United States Government <img class="flag" src="{{ site.url }}static/img/us_flag_small.png">
+      An official website of the United States Government <img class="flag" src="{{ site.baseurl }}/static/img/us_flag_small.png">
     </p>
   </div>
 </aside>

--- a/about/index.html
+++ b/about/index.html
@@ -13,7 +13,7 @@ description: This is a sample beta site for Federal natural resource revenues.
 	{% for name in site.data.offices %}
 	<article>
 		<div>
-			<img src="{{ site.url }}{{ name.mark }}" alt="{{ name.name }}">
+			<img src="{{ site.baseurl }}{{ name.mark }}" alt="{{ name.name }}">
 		</div>
 		<div>
 			<h1>{{ name.full }}</h1>

--- a/data/index.html
+++ b/data/index.html
@@ -10,7 +10,7 @@ description: This is a sample beta site for Federal natural resource revenues.
 <div class="dashboard">
 
   <nav class="dashboard-nav">
-    <a href="{{ site.url }}" itemprop="url">&#8592; Home </a>
+    <a href="{{ site.baseurl }}" itemprop="url">&#8592; Home </a>
     &#124; Natural Resource Revenue from U.S. Federal Lands
   </nav>
 
@@ -20,10 +20,10 @@ description: This is a sample beta site for Federal natural resource revenues.
     <div class="dashboard-choices"><h1>Choose a year [2012]</h1></div>
   </div>
 
-  
+
 <!-- START Side Options Nav -->
-  <div class="side-nav" id="OptionsList"> 
-    
+  <div class="side-nav" id="OptionsList">
+
     <h1><label class="label-switch last" for="chk-energy">Oil &amp; Gas
       <input class="groupCheckbox" type="checkbox" name="energygroup" value="energy" id="chk-energy" checked />
       <div class="checkbox"></div>
@@ -61,7 +61,7 @@ description: This is a sample beta site for Federal natural resource revenues.
         <div class="checkbox"></div>
       </label>
     </div>
-  
+
     <h1><label class="label-switch last" for="chk-renewables">Renewables
       <input class="groupCheckbox" type="checkbox" name="renewables" value="renewables" id="chk-renewables" checked />
       <div class="checkbox"></div>
@@ -82,7 +82,7 @@ description: This is a sample beta site for Federal natural resource revenues.
         <div class="checkbox"></div>
       </label> -->
     </div>
-  
+
     <h1><label class="label-switch" for="chk-minerals">Other
       <input class="groupCheckbox" type="checkbox" name="energygroup" value="other" id="chk-minerals" checked />
       <div class="checkbox"></div>
@@ -119,7 +119,7 @@ description: This is a sample beta site for Federal natural resource revenues.
       </label>
     </div>
     <div class="side-nav-right">
-      <label class="label-switch" for="chk-Phosphate">Phosphate 
+      <label class="label-switch" for="chk-Phosphate">Phosphate
         <input class="other commodity" type="checkbox" name="commodity" value="Phosphate" id="chk-Phosphate" checked />
         <div class="checkbox"></div>
       </label>
@@ -132,7 +132,7 @@ description: This is a sample beta site for Federal natural resource revenues.
         <div class="checkbox"></div>
       </label>
     </div>
-    
+
   </div>
 <!-- END Side Options Nav --
 
@@ -158,7 +158,7 @@ description: This is a sample beta site for Federal natural resource revenues.
         <input type="text" id="table-search"></input>
         <div><a href="javascript:toggle_divs('#toggleDivLink','#dashboard-totals-table','#dashboard-table','Show Full Table','Show Table by Company')" id="toggleDivLink">Show Full Table</a></div>
         <table class='table table-hover dc-data-table' id='dashboard-totals-table'>
-          
+
           <thead>
             <tr class="header">
               <th>
@@ -174,9 +174,9 @@ description: This is a sample beta site for Federal natural resource revenues.
             </tr>
           </thead>
         </table>
-        
+
         <table class='table table-hover dc-data-table' id='dashboard-table' style="display:none">
-          
+
           <thead>
             <tr class="header">
               <th>
@@ -211,7 +211,7 @@ description: This is a sample beta site for Federal natural resource revenues.
 <!-- END Main Data Dashboard -->
 
 </main>
-<script src='{{ site.url }}static/js/dashboard.js'></script>
+<script src='{{ site.baseurl }}/static/js/dashboard.js'></script>
 <script type="text/javascript">
  $("#table-search").on('input',function(){
    text_filter(companyDimension,this.value);

--- a/index.html
+++ b/index.html
@@ -32,7 +32,7 @@ description: This is a sample beta site for Federal natural resource revenues.
 
 <!-- splash -->
 <section id="first1" class="splash">
-  {% include nav.html %} 
+  {% include nav.html %}
   <div class="container">
     <div class="title">
       <h1>Natural Resource Revenues</h1>
@@ -43,7 +43,7 @@ description: This is a sample beta site for Federal natural resource revenues.
     <div class="intro">
       <p>The U.S. earns revenue on natural resources extracted from its lands. This is a major source of revenue for the country and for local municipalities.</p>
       <p>Learn about U.S. natural resource sectors, how resources become revenues, and where the money goes. Go on, scroll down.
-      <img src="{{ site.url }}static/img/scroll-down.png" alt="You should scroll down. There is more to learn!" class="moreDown breathe">
+      <img src="{{ site.baseurl }}/static/img/scroll-down.png" alt="You should scroll down. There is more to learn!" class="moreDown breathe">
 
       </p>
     </div>
@@ -62,20 +62,20 @@ description: This is a sample beta site for Federal natural resource revenues.
       <span class="sectors-big-text">$97.5</span> billion between 2003 to 2013.</h1>
 
       <h2>Learn about U.S. natural resources:</h2>
-      
-      <img src="{{ site.url }}static/img/icon_375.svg" alt="Barrel of oil" class="sectors-img">
+
+      <img src="{{ site.baseurl }}/static/img/icon_375.svg" alt="Barrel of oil" class="sectors-img">
       <p><strong>Oil.</strong> Crude oil is produced in 31 states and U.S. coastal waters. In 2012, 61% of&#133; <a href="{{ site.baseurl }}/sectors/" itemprop="url">more&#8594;</a></p>
 
-      <img src="{{ site.url }}static/img/icon_12555.svg" alt="Flame" class="sectors-img">
+      <img src="{{ site.baseurl }}/static/img/icon_12555.svg" alt="Flame" class="sectors-img">
       <p><strong>Natural gas.</strong> In 2012, about 25% of energy used in the U. S. came from natural gas, and the&#133; <a href="{{ site.baseurl }}/sectors/" itemprop="url">more&#8594;</a></p>
-      
-      <img src="{{ site.url }}static/img/icon_5846.svg" alt="Lump of coal" class="sectors-img">
+
+      <img src="{{ site.baseurl }}/static/img/icon_5846.svg" alt="Lump of coal" class="sectors-img">
       <p><strong>Coal.</strong> In 2012, 1,016.4 million short tons of coal were mined in 25 states. Wyoming&#133; <a href="{{ site.baseurl }}/sectors/" itemprop="url">more&#8594;</a></p>
 
-      <img src="{{ site.url }}static/img/icon_2070.svg" alt="Geothermal plant" class="sectors-img">
+      <img src="{{ site.baseurl }}/static/img/icon_2070.svg" alt="Geothermal plant" class="sectors-img">
       <p><strong>Geothermal.</strong> In 2013, U.S. geothermal power plants produced about 17 billion kilowatthours&#133; <a href="{{ site.baseurl }}/sectors/" itemprop="url">more&#8594;</a></p>
 
-      <img src="{{ site.url }}static/img/icon_29006.svg" alt="Vertical ellipses" class="sectors-img">
+      <img src="{{ site.baseurl }}/static/img/icon_29006.svg" alt="Vertical ellipses" class="sectors-img">
       <p><strong>Other revenues.</strong> In 2013, Federal lands produced a wide variety of minerals. For example&#133; <a href="{{ site.baseurl }}/sectors/" itemprop="url">more&#8594;</a></p>
     </div>
 
@@ -95,8 +95,8 @@ description: This is a sample beta site for Federal natural resource revenues.
     </div>
 
     <div class="sectors-social">
-      <img src="{{ site.url }}static/img/icon_4501.svg" alt="Download" class="share">
-      <img src="{{ site.url }}static/img/icon_7584.svg" alt="Share" class="share">
+      <img src="{{ site.baseurl }}/static/img/icon_4501.svg" alt="Download" class="share">
+      <img src="{{ site.baseurl }}/static/img/icon_7584.svg" alt="Share" class="share">
     </div>
 
 </section>
@@ -123,11 +123,11 @@ description: This is a sample beta site for Federal natural resource revenues.
   <div class="map-container">
       <div id='map'></div>
       <div id='map-info-pane' class='map-info-pane'></div>
-      
+
       <div id='map-comodities-pane' class='map-comodities-pane'>
 
         <a href='javascript:' class='oil' data-value='oil' tabindex='0' role="button" aria-pressed="true">
-          <svg class="eiti-icon-oil"><use xlink:href="{{ site.url }}static/fonts/EITI/icons.svg#eiti-icon-oil"></use></svg>
+          <svg class="eiti-icon-oil"><use xlink:href="{{ site.baseurl }}/static/fonts/EITI/icons.svg#eiti-icon-oil"></use></svg>
           <div class="tooltip-item">
           <h1>Oil<sup> 1</sup></h1>
             <!-- <div class="tooltip">
@@ -137,7 +137,7 @@ description: This is a sample beta site for Federal natural resource revenues.
         </a>
 
         <a href='javascript:' class='ngl' tabindex='0' role="button" aria-pressed="false">
-          <svg class="eiti-icon-gas"><use xlink:href="{{ site.url }}static/fonts/EITI/icons.svg#eiti-icon-gas"></use></svg>
+          <svg class="eiti-icon-gas"><use xlink:href="{{ site.baseurl }}/static/fonts/EITI/icons.svg#eiti-icon-gas"></use></svg>
           <div class="tooltip-item">
           <h1>Gas<sup> 2</sup></h1>
             <!-- <div class="tooltip">
@@ -147,7 +147,7 @@ description: This is a sample beta site for Federal natural resource revenues.
         </a>
 
         <a href='javascript:' class='coal' tabindex='0' role="button" aria-pressed="false">
-          <svg class="eiti-icon-coal"><use xlink:href="{{ site.url }}static/fonts/EITI/icons.svg#eiti-icon-coal"></use></svg>
+          <svg class="eiti-icon-coal"><use xlink:href="{{ site.baseurl }}/static/fonts/EITI/icons.svg#eiti-icon-coal"></use></svg>
           <div class="tooltip-item">
           <h1>Coal<sup> 2</sup></h1>
             <!-- <div class="tooltip">
@@ -157,7 +157,7 @@ description: This is a sample beta site for Federal natural resource revenues.
         </a>
 
         <a href='javascript:' class='other' tabindex='0' role="button" aria-pressed="false">
-          <svg class="eiti-icon-other"><use xlink:href="{{ site.url }}static/fonts/EITI/icons.svg#eiti-icon-other"></use></svg>
+          <svg class="eiti-icon-other"><use xlink:href="{{ site.baseurl }}/static/fonts/EITI/icons.svg#eiti-icon-other"></use></svg>
           <div class="tooltip-item">
           <h1>Other<sup> 3</sup></h1>
             <!-- <div class="tooltip">
@@ -167,7 +167,7 @@ description: This is a sample beta site for Federal natural resource revenues.
         </a>
 
         <a href='javascript:' class='wind' tabindex='0' role="button" aria-pressed="false">
-          <svg class="eiti-icon-wind"><use xlink:href="{{ site.url }}static/fonts/EITI/icons.svg#eiti-icon-wind"></use></svg>
+          <svg class="eiti-icon-wind"><use xlink:href="{{ site.baseurl }}/static/fonts/EITI/icons.svg#eiti-icon-wind"></use></svg>
           <div class="tooltip-item">
           <h1>Wind<sup> 4</sup></h1>
             <!-- <div class="tooltip">
@@ -177,7 +177,7 @@ description: This is a sample beta site for Federal natural resource revenues.
         </a>
 
         <a href='javascript:' class='geo' tabindex='0' role="button" aria-pressed="false">
-          <svg class="eiti-icon-geo"><use xlink:href="{{ site.url }}static/fonts/EITI/icons.svg#eiti-icon-geo"></use></svg>
+          <svg class="eiti-icon-geo"><use xlink:href="{{ site.baseurl }}/static/fonts/EITI/icons.svg#eiti-icon-geo"></use></svg>
           <div class="tooltip-item">
             <h1 class="small">Geothermal<sup> 5</sup></h1>
             <!-- <div class="tooltip">
@@ -232,7 +232,7 @@ description: This is a sample beta site for Federal natural resource revenues.
 </section>
 
 <section class="section medium-gray disbursement">
-  
+
   <div class="container">
     <div class=" viz-title">
       <h1>Oil &amp; Gas Revenue Flow</h1>
@@ -286,10 +286,10 @@ description: This is a sample beta site for Federal natural resource revenues.
         </div>
       </div>
     </section>
-    
+
     <div class="sectors-social">
-      <img src="{{ site.url }}static/img/icon_4501.svg" alt="Download" class="share">
-      <img src="{{ site.url }}static/img/icon_7584.svg" alt="Share" class="share">
+      <img src="{{ site.baseurl }}/static/img/icon_4501.svg" alt="Download" class="share">
+      <img src="{{ site.baseurl }}/static/img/icon_7584.svg" alt="Share" class="share">
     </div>
 
   </div>
@@ -300,14 +300,14 @@ description: This is a sample beta site for Federal natural resource revenues.
 </main>
 
 <!--Graph scripts-->
-<script src='{{ site.url }}static/data/revenue2013.json'></script>
-<script src='{{ site.url }}static/data/0_GOM-planarea-NAD27-simp.geojson'></script>
-<script src='{{ site.url }}static/data/0_PC-planarea-NAD83-simp.geojson'></script>
-<script src='{{ site.url }}static/data/0_AK-planarea-NAD83-simp.geojson'></script>
-<script src='{{ site.url }}static/data/0_ATL-planarea-NAD83-simp.geojson'></script>
-<script src='{{ site.url }}static/js/onrrmap.js'></script>
-<script src='{{ site.url }}static/js/sectors-revenue.js'></script>
-<script src='{{ site.url }}static/js/disbursement.js'></script>
+<script src='{{ site.baseurl }}/static/data/revenue2013.json'></script>
+<script src='{{ site.baseurl }}/static/data/0_GOM-planarea-NAD27-simp.geojson'></script>
+<script src='{{ site.baseurl }}/static/data/0_PC-planarea-NAD83-simp.geojson'></script>
+<script src='{{ site.baseurl }}/static/data/0_AK-planarea-NAD83-simp.geojson'></script>
+<script src='{{ site.baseurl }}/static/data/0_ATL-planarea-NAD83-simp.geojson'></script>
+<script src='{{ site.baseurl }}/static/js/onrrmap.js'></script>
+<script src='{{ site.baseurl }}/static/js/sectors-revenue.js'></script>
+<script src='{{ site.baseurl }}/static/js/disbursement.js'></script>
 
 <script>
 document.querySelector( "#nav-toggle" ).addEventListener( "click", function() {

--- a/static/js/disbursement.js
+++ b/static/js/disbursement.js
@@ -53,7 +53,7 @@ d3.csv("static/data/disbursement-summary-data.csv",function(disbursement_data){
     }
 
     function order_data(data, key){
-       
+
         return data.sort(function(a,b){
             return parseFloat(b[key])-parseFloat(a[key]);
         });
@@ -123,7 +123,7 @@ d3.csv("static/data/disbursement-summary-data.csv",function(disbursement_data){
         .html(function(d) {
             return "<div class='disbursement_bubble_content'>" + d["Bubble Name"] + "</div>" + "<div class='disbursement_bubble_rollover'>Total: $" + parseFloat(d["Total"]).formatMoney(2, '.', ',') + "</div>";
         });
-    
+
     var circleTip = d3.tip()
         .attr('class', 'd3-tip')
         .offset([-10, 0])
@@ -166,7 +166,7 @@ d3.csv("static/data/disbursement-summary-data.csv",function(disbursement_data){
         offshoreYearDim.filterAll();
         onshoreYearDim.filter(function(d){
             if(d == year)
-                return d; 
+                return d;
         });
         offshoreYearDim.filter(function(d){
             if(d == year)
@@ -312,7 +312,7 @@ d3.csv("static/data/disbursement-summary-data.csv",function(disbursement_data){
                     $(this).siblings("div.info_bubble").children().html(thisDetail) //after the animation is done, insert the new text into the content div
                 }
             })
-        } else //Shrink clicked bubble 
+        } else //Shrink clicked bubble
         {
             //$(this).css({"position":"relative", "z-index":"1"});
             thisContentDiv.html(thisName)
@@ -351,26 +351,26 @@ function findRel(that, thatClass, searchTerm, obj) {
 
 //JSON content
 var where_stats_data = {
-    //More info on click 
+    //More info on click
     "statsOffshore": [
-        //Remember that the count starts at zero 
-        //NOTE: img links are currently hard coded to gh pages site -- fix later -- figure out how to make these relative given that Jekyll won't parse JS files and so can't use {{ site.url }} 
+        //Remember that the count starts at zero
+        //NOTE: img links are currently hard coded to gh pages site -- fix later -- figure out how to make these relative given that Jekyll won't parse JS files and so can't use {{ site.url }}
         {
-            //Array ID -> 0 
+            //Array ID -> 0
             "Title": "U.S. Treasury",
-            "Content": "<div class=\"disbursement_bubble_details\" style=\"padding-top: 20px;\"><h1>U.S. Treasury</h1><p>Some offshore revenue goes into the <a href=\"http://www.gasb.org/cs/ContentServer?pagename=GASB/GASBContent_C/UsersArticlePage&cid=1176156735732\">U.S. General Fund</a>, which is the same place that money from individual and corporate income taxes go. A general fund is a government's basic operating fund and accounts for everything not accounted for in another fund. The U.S. General Fund pays for roughly two-thirds of all federal expenditures, including:</p><div class=\"disbursement_bubble_details_images\"><img src=\"http://meiqimichelle.github.io/d3-minihack/assets/img/icon_1397.svg\" alt=\"Dogtags\"><h2>U.S. Military</h2></div><div class=\"disbursement_bubble_details_images\"><img src=\"http://meiqimichelle.github.io/d3-minihack/assets/img/icon_13130.svg\" alt=\"Park\"><h2>U.S. Parks</h2></div><div class=\"disbursement_bubble_details_images\"><img src=\"http://meiqimichelle.github.io/d3-minihack/assets/img/icon_1567.svg\" alt=\"Book and test tube\"><h2>U.S. Schools</h2></div></div>",
+            "Content": "<div class=\"disbursement_bubble_details\" style=\"padding-top: 20px;\"><h1>U.S. Treasury</h1><p>Some offshore revenue goes into the <a href=\"http://www.gasb.org/cs/ContentServer?pagename=GASB/GASBContent_C/UsersArticlePage&cid=1176156735732\">U.S. General Fund</a>, which is the same place that money from individual and corporate income taxes go. A general fund is a government's basic operating fund and accounts for everything not accounted for in another fund. The U.S. General Fund pays for roughly two-thirds of all federal expenditures, including:</p><div class=\"disbursement_bubble_details_images\"><img src=\"https://meiqimichelle.github.io/d3-minihack/assets/img/icon_1397.svg\" alt=\"Dogtags\"><h2>U.S. Military</h2></div><div class=\"disbursement_bubble_details_images\"><img src=\"https://meiqimichelle.github.io/d3-minihack/assets/img/icon_13130.svg\" alt=\"Park\"><h2>U.S. Parks</h2></div><div class=\"disbursement_bubble_details_images\"><img src=\"https://meiqimichelle.github.io/d3-minihack/assets/img/icon_1567.svg\" alt=\"Book and test tube\"><h2>U.S. Schools</h2></div></div>",
         }, {
-            //Array ID -> 1 
+            //Array ID -> 1
             "Title": "States",
-            "Content": "<div class=\"disbursement_bubble_details\" style=\"padding-top: 20px;\"><h1>States</h1><p>Offshore revenues go to states in several different ways. If the revenues are from leases the <a href=\"http\://statistics.onrr.gov/PDF/FAQs.pdf\">8(g) region</a>, they go straight to states. If they are in the <a href=\"http\://www.boem.gov/Oil-and-Gas-Energy-Program/Energy-Economics/Revenue-Sharing/Index.aspx\">GOMESA region</a>, some of these funds go directly to 'Coastal Political Subdivions' such as counties and parishes. It is up to the county, parish or state to decide how to use the revenues.</p><div class=\"disbursement_bubble_details_images\"><img src=\"http://meiqimichelle.github.io/d3-minihack/assets/img/icon_4572.svg\" alt=\"Offshore oil rig\"><h2><a href=\"http\://statistics.onrr.gov/PDF/FAQs.pdf\">Learn about 8(g) &#8594;</a></h2></div><div class=\"disbursement_bubble_details_images\"><img src=\"http://meiqimichelle.github.io/d3-minihack/assets/img/icon_8676.svg\" alt=\"Coast\"><h2><a href=\"http\://www.boem.gov/Oil-and-Gas-Energy-Program/Energy-Economics/Revenue-Sharing/Index.aspx\">Learn about GOMESA &#8594;</a></h2></div></div>",
+            "Content": "<div class=\"disbursement_bubble_details\" style=\"padding-top: 20px;\"><h1>States</h1><p>Offshore revenues go to states in several different ways. If the revenues are from leases the <a href=\"http\://statistics.onrr.gov/PDF/FAQs.pdf\">8(g) region</a>, they go straight to states. If they are in the <a href=\"http\://www.boem.gov/Oil-and-Gas-Energy-Program/Energy-Economics/Revenue-Sharing/Index.aspx\">GOMESA region</a>, some of these funds go directly to 'Coastal Political Subdivions' such as counties and parishes. It is up to the county, parish or state to decide how to use the revenues.</p><div class=\"disbursement_bubble_details_images\"><img src=\"https://meiqimichelle.github.io/d3-minihack/assets/img/icon_4572.svg\" alt=\"Offshore oil rig\"><h2><a href=\"http\://statistics.onrr.gov/PDF/FAQs.pdf\">Learn about 8(g) &#8594;</a></h2></div><div class=\"disbursement_bubble_details_images\"><img src=\"https://meiqimichelle.github.io/d3-minihack/assets/img/icon_8676.svg\" alt=\"Coast\"><h2><a href=\"http\://www.boem.gov/Oil-and-Gas-Energy-Program/Energy-Economics/Revenue-Sharing/Index.aspx\">Learn about GOMESA &#8594;</a></h2></div></div>",
         }, {
             //Array ID -> 2
             "Title": "Historic Preservation Fund",
-            "Content": "<div class=\"disbursement_bubble_details\"><h1>Historic Preservation Fund</h1><p>The <a href=\"http\://www.nps.gov/history/hpg/\">Historic Preservation Fund</a> helps preserve U.S. historical and archaeological sites and cultural heritage through grants to State and Tribal Historic Preservation Offices. Some examples of activities include:</p><div class=\"disbursement_bubble_details_images\"><img src=\"http://meiqimichelle.github.io/d3-minihack/assets/img/icon_1566.svg\" alt=\"City buildings\"><h2><a href=\"http\://www.michiganmodern.org/\">Survey Modernist Architecture, Michigan &#8594;</a></h2></div><div class=\"disbursement_bubble_details_images\"><img src=\"http://meiqimichelle.github.io/d3-minihack/assets/img/icon_10119.svg\" alt=\"Schoolhouse\"><h2><a href=\"http\://ncptt.nps.gov/blog/tribal-heritage-grants/\">Restore Peoria Schoolhouse, Peoria Tribe of Indians, Oklahoma &#8594;</a></h2></div><div class=\"disbursement_bubble_details_images\"><img src=\"http://meiqimichelle.github.io/d3-minihack/assets/img/icon_7038.svg\" alt=\"Video camera\"><h2><a href=\"http\://ncptt.nps.gov/blog/tribal-heritage-grants/\">Document Yup’ik Songs & Dances, Calista Elders Council of Alaska &#8594;</a></h2></div></div>",
+            "Content": "<div class=\"disbursement_bubble_details\"><h1>Historic Preservation Fund</h1><p>The <a href=\"http\://www.nps.gov/history/hpg/\">Historic Preservation Fund</a> helps preserve U.S. historical and archaeological sites and cultural heritage through grants to State and Tribal Historic Preservation Offices. Some examples of activities include:</p><div class=\"disbursement_bubble_details_images\"><img src=\"https://meiqimichelle.github.io/d3-minihack/assets/img/icon_1566.svg\" alt=\"City buildings\"><h2><a href=\"http\://www.michiganmodern.org/\">Survey Modernist Architecture, Michigan &#8594;</a></h2></div><div class=\"disbursement_bubble_details_images\"><img src=\"https://meiqimichelle.github.io/d3-minihack/assets/img/icon_10119.svg\" alt=\"Schoolhouse\"><h2><a href=\"http\://ncptt.nps.gov/blog/tribal-heritage-grants/\">Restore Peoria Schoolhouse, Peoria Tribe of Indians, Oklahoma &#8594;</a></h2></div><div class=\"disbursement_bubble_details_images\"><img src=\"https://meiqimichelle.github.io/d3-minihack/assets/img/icon_7038.svg\" alt=\"Video camera\"><h2><a href=\"http\://ncptt.nps.gov/blog/tribal-heritage-grants/\">Document Yup’ik Songs & Dances, Calista Elders Council of Alaska &#8594;</a></h2></div></div>",
         }, {
             //Array ID -> 3
             "Title": "Land &amp; Water Conservation Fund",
-            "Content": "<div class=\"disbursement_bubble_details\"><h1>Land &amp; Water Conservation Fund</h1><p>The <a href=\"http\://www.nps.gov/lwcf/\">Land & Water Conservation Fund</a> provides matching grants to states and local governments to buy and develop public outdoor recreation areas. It has supported projects in all 50 states and U.S. territories, creating community parks and trails and protecting clean water sources. Here are a few places that were funded by the LWCF:</p><div class=\"disbursement_bubble_details_images\"><img src=\"http://meiqimichelle.github.io/d3-minihack/assets/img/icon_16251.svg\" alt=\"Mountains\"><h2><a href=\"http\://www.emnrd.state.nm.us/SPD/eaglenestlakestatepark.html\">Eagle Nest Lake State Park, New Mexico &#8594;</a></h2></div><div class=\"disbursement_bubble_details_images\"><img src=\"http://meiqimichelle.github.io/d3-minihack/assets/img/icon_26235.svg\" alt=\"Playground\"><h2><a href=\"http\://www.mitchellparkdc.org/history.html\">Mitchell Park, District of Columbia &#8594;</a></h2></div><div class=\"disbursement_bubble_details_images\"><img src=\"http://meiqimichelle.github.io/d3-minihack/assets/img/icon_25079.svg\" alt=\"Baseball field\"><h2><a href=\"http\://www.ofallon.org/parks/pages/family-sports-park\">Family Sports Park, Illinois &#8594;</a></h2></div></div>",
+            "Content": "<div class=\"disbursement_bubble_details\"><h1>Land &amp; Water Conservation Fund</h1><p>The <a href=\"http\://www.nps.gov/lwcf/\">Land & Water Conservation Fund</a> provides matching grants to states and local governments to buy and develop public outdoor recreation areas. It has supported projects in all 50 states and U.S. territories, creating community parks and trails and protecting clean water sources. Here are a few places that were funded by the LWCF:</p><div class=\"disbursement_bubble_details_images\"><img src=\"https://meiqimichelle.github.io/d3-minihack/assets/img/icon_16251.svg\" alt=\"Mountains\"><h2><a href=\"http\://www.emnrd.state.nm.us/SPD/eaglenestlakestatepark.html\">Eagle Nest Lake State Park, New Mexico &#8594;</a></h2></div><div class=\"disbursement_bubble_details_images\"><img src=\"https://meiqimichelle.github.io/d3-minihack/assets/img/icon_26235.svg\" alt=\"Playground\"><h2><a href=\"http\://www.mitchellparkdc.org/history.html\">Mitchell Park, District of Columbia &#8594;</a></h2></div><div class=\"disbursement_bubble_details_images\"><img src=\"https://meiqimichelle.github.io/d3-minihack/assets/img/icon_25079.svg\" alt=\"Baseball field\"><h2><a href=\"http\://www.ofallon.org/parks/pages/family-sports-park\">Family Sports Park, Illinois &#8594;</a></h2></div></div>",
         }, {
             //Array ID -> 2
             "Title": "Other Funds",
@@ -379,20 +379,20 @@ var where_stats_data = {
     ],
 
     "statsOnshore": [
-        //Remember that the count starts at zero 
-        //NOTE: img links are currently hard coded to gh pages site -- fix later -- figure out how to make these relative given that Jekyll won't parse JS files and so can't use {{ site.url }} 
+        //Remember that the count starts at zero
+        //NOTE: img links are currently hard coded to gh pages site -- fix later -- figure out how to make these relative given that Jekyll won't parse JS files and so can't use {{ site.url }}
         {
-            //Array ID -> 0 
+            //Array ID -> 0
             "Title": "States",
-            "Content": "<div class=\"disbursement_bubble_details\"><h1>States</h1><p>The state share of onshore revenues mostly go directly to states, with percentages going to several other funds and state entities. For example, some revenue from geothermal resources goes directly to counties; some revenue from Federal land management agencies returns to each; some is used for flood control. It's up to each county and state to decide how to use the revenue.</p><div class=\"disbursement_bubble_details_images\"><img src=\"http://meiqimichelle.github.io/d3-minihack/assets/img/icon_2070.svg\" alt=\"Geothermal energy plant\"><h2><a href=\"http://www.blm.gov/wo/st/en/prog/energy/geothermal.html\">Some geothermal energy revenues go directly to counties &#8594;</a></h2></div><div class=\"disbursement_bubble_details_images\"><img src=\"http://meiqimichelle.github.io/d3-minihack/assets/img/icon_38222.svg\" alt=\"U.S. States\"><h2><a href=\"http://statistics.onrr.gov/\">Other resource revenues go to states &#8594;</a></h2></div></div>",
+            "Content": "<div class=\"disbursement_bubble_details\"><h1>States</h1><p>The state share of onshore revenues mostly go directly to states, with percentages going to several other funds and state entities. For example, some revenue from geothermal resources goes directly to counties; some revenue from Federal land management agencies returns to each; some is used for flood control. It's up to each county and state to decide how to use the revenue.</p><div class=\"disbursement_bubble_details_images\"><img src=\"https://meiqimichelle.github.io/d3-minihack/assets/img/icon_2070.svg\" alt=\"Geothermal energy plant\"><h2><a href=\"http://www.blm.gov/wo/st/en/prog/energy/geothermal.html\">Some geothermal energy revenues go directly to counties &#8594;</a></h2></div><div class=\"disbursement_bubble_details_images\"><img src=\"https://meiqimichelle.github.io/d3-minihack/assets/img/icon_38222.svg\" alt=\"U.S. States\"><h2><a href=\"http://statistics.onrr.gov/\">Other resource revenues go to states &#8594;</a></h2></div></div>",
         }, {
-            //Array ID -> 1 
+            //Array ID -> 1
             "Title": "Reclamation Fund",
-            "Content": "<div class=\"disbursement_bubble_details\" style=\"padding-top: 20px;\"><h1>Reclamation Fund</h1><p><a href=\"http://www.nps.gov/nr/travel/ReclamationDamsAndWaterProjects/Mission_of_the_Bureau_of_Reclamation.html\">The Reclamation Fund</a> is a special fund established by the United States Congress under the Reclamation Act of 1902 to pay for Bureau of Reclamation projects. The Bureau of Reclamation is best known for its dams and power plants which provide:</p><div class=\"disbursement_bubble_details_images\"><img src=\"http://meiqimichelle.github.io/d3-minihack/assets/img/icon_18711.svg\" alt=\"Farm\"><h2><a href=\"http://www.usbr.gov/facts.html\">Irrigation water for 10 million acres of farmland &#8594;</a></h2></div><div class=\"disbursement_bubble_details_images\"><img src=\"http://meiqimichelle.github.io/d3-minihack/assets/img/icon_265.svg\" alt=\"Dam\"><h2><a href=\"http://www.usbr.gov/facts.html\">40 billion kilowatt hours of energy produced from hydroelectric power &#8594;</a></h2></div></div>",
+            "Content": "<div class=\"disbursement_bubble_details\" style=\"padding-top: 20px;\"><h1>Reclamation Fund</h1><p><a href=\"http://www.nps.gov/nr/travel/ReclamationDamsAndWaterProjects/Mission_of_the_Bureau_of_Reclamation.html\">The Reclamation Fund</a> is a special fund established by the United States Congress under the Reclamation Act of 1902 to pay for Bureau of Reclamation projects. The Bureau of Reclamation is best known for its dams and power plants which provide:</p><div class=\"disbursement_bubble_details_images\"><img src=\"https://meiqimichelle.github.io/d3-minihack/assets/img/icon_18711.svg\" alt=\"Farm\"><h2><a href=\"http://www.usbr.gov/facts.html\">Irrigation water for 10 million acres of farmland &#8594;</a></h2></div><div class=\"disbursement_bubble_details_images\"><img src=\"https://meiqimichelle.github.io/d3-minihack/assets/img/icon_265.svg\" alt=\"Dam\"><h2><a href=\"http://www.usbr.gov/facts.html\">40 billion kilowatt hours of energy produced from hydroelectric power &#8594;</a></h2></div></div>",
         }, {
             //Array ID -> 2
             "Title": "U.S. Treasury",
-            "Content": "<div class=\"disbursement_bubble_details\" style=\"padding-top: 20px;\"><h1>U.S. Treasury</h1><p>Some offshore revenue goes into the <a href=\"http://www.gasb.org/cs/ContentServer?pagename=GASB/GASBContent_C/UsersArticlePage&cid=1176156735732\">U.S. General Fund</a>, which is the same place that money from individual and corporate income taxes go. A general fund is a government's basic operating fund and accounts for everything not accounted for in another fund. The U.S. General Fund pays for roughly two-thirds of all federal expenditures, including:</p><div class=\"disbursement_bubble_details_images\"><img src=\"http://meiqimichelle.github.io/d3-minihack/assets/img/icon_1397.svg\" alt=\"Dogtags\"><h2>U.S. Military</h2></div><div class=\"disbursement_bubble_details_images\"><img src=\"http://meiqimichelle.github.io/d3-minihack/assets/img/icon_13130.svg\" alt=\"Park\"><h2>U.S. Parks</h2></div><div class=\"disbursement_bubble_details_images\"><img src=\"http://meiqimichelle.github.io/d3-minihack/assets/img/icon_1567.svg\" alt=\"Book and test tube\"><h2>U.S. Schools</h2></div></div>",
+            "Content": "<div class=\"disbursement_bubble_details\" style=\"padding-top: 20px;\"><h1>U.S. Treasury</h1><p>Some offshore revenue goes into the <a href=\"http://www.gasb.org/cs/ContentServer?pagename=GASB/GASBContent_C/UsersArticlePage&cid=1176156735732\">U.S. General Fund</a>, which is the same place that money from individual and corporate income taxes go. A general fund is a government's basic operating fund and accounts for everything not accounted for in another fund. The U.S. General Fund pays for roughly two-thirds of all federal expenditures, including:</p><div class=\"disbursement_bubble_details_images\"><img src=\"https://meiqimichelle.github.io/d3-minihack/assets/img/icon_1397.svg\" alt=\"Dogtags\"><h2>U.S. Military</h2></div><div class=\"disbursement_bubble_details_images\"><img src=\"https://meiqimichelle.github.io/d3-minihack/assets/img/icon_13130.svg\" alt=\"Park\"><h2>U.S. Parks</h2></div><div class=\"disbursement_bubble_details_images\"><img src=\"https://meiqimichelle.github.io/d3-minihack/assets/img/icon_1567.svg\" alt=\"Book and test tube\"><h2>U.S. Schools</h2></div></div>",
         }, {
             //Array ID -> 2
             "Title": "American Indian Tribes",

--- a/static/js/helpers.js
+++ b/static/js/helpers.js
@@ -15,12 +15,12 @@ function clean_monetary_float (f){
 }
 
 Number.prototype.formatMoney = function(c, d, t){
-var n = this, 
-    c = isNaN(c = Math.abs(c)) ? 2 : c, 
-    d = d == undefined ? "." : d, 
-    t = t == undefined ? "," : t, 
-    s = n < 0 ? "-" : "", 
-    i = parseInt(n = Math.abs(+n || 0).toFixed(c)) + "", 
+var n = this,
+    c = isNaN(c = Math.abs(c)) ? 2 : c,
+    d = d == undefined ? "." : d,
+    t = t == undefined ? "," : t,
+    s = n < 0 ? "-" : "",
+    i = parseInt(n = Math.abs(+n || 0).toFixed(c)) + "",
     j = (j = i.length) > 3 ? j % 3 : 0;
    return s + (j ? i.substr(0, j) + t : "") + i.substr(j).replace(/(\d{3})(?=\d)/g, "$1" + t) + (c ? d + Math.abs(n - i).toFixed(c).slice(2) : "");
  };
@@ -88,15 +88,15 @@ function update_graph_options(elem,dimension){
 		}
 	});
 	dimension.filterAll();
-	dimension.filter(function(d){	
+	dimension.filter(function(d){
 			if (a.indexOf(d) > -1)
 			{
 				return true;
 			}
-			else 
+			else
 				return false;
 	});
-	
+
 
 	draw_totals_table();
 	dc.redrawAll();
@@ -124,7 +124,7 @@ function download_data(dimension){
 	{
 			csv +=keys[i]+",";
 	}
-		
+
 	csv += "\n";
 
 	f.forEach(function(d){
@@ -146,14 +146,14 @@ function download_map_data(data){
 	for (var i = 0; i<data.length; i++)
 	{
 		if (!data[i].hasOwnProperty('features'))
-			continue;	
+			continue;
 		var featuresArray = data[i].features;
 		for(var n = 0; n<featuresArray.length; n++)
 		{
 			if (featuresArray[n].hasOwnProperty('properties'))
 				var obj=featuresArray[n].properties;
 			else
-				continue;	
+				continue;
 			var propArray = [];
 			if (obj.name)
 			{
@@ -230,12 +230,12 @@ function draw_totals_table(){
 	//Get the data from the new group and assign to d
 	var d = g.top(Infinity);
 
-	//Take JSON in d and put in jsonData with new structure for ease of use 
+	//Take JSON in d and put in jsonData with new structure for ease of use
 	d.forEach(function(d){
 		if (d.value != 0)
 			jsonData.push({"Company Name" : d.key, "Total Revenue" : d.value});
 	});
-	
+
 	//Add jsonData to a crossfilter
 	var jdx = crossfilter(jsonData);
 	//Set dimension to Company Name
@@ -273,11 +273,11 @@ function toggle_divs(that, div1, div2, linkText1, linkText2){
 
 /********************************************************************************
 From:
-http://stackoverflow.com/questions/979975/how-to-get-the-value-from-url-parameter
+https://stackoverflow.com/questions/979975/how-to-get-the-value-from-url-parameter
 Used to get url paramaters
 ********************************************************************************/
 var QueryString = function () {
-  // This function is anonymous, is executed immediately and 
+  // This function is anonymous, is executed immediately and
   // the return value is assigned to QueryString!
   var query_string = {};
   var query = window.location.search.substring(1);
@@ -296,12 +296,12 @@ var QueryString = function () {
     } else {
       query_string[pair[0]].push(pair[1]);
     }
-  } 
+  }
     return query_string;
 } ();
 
 /***********************************************************************************************
-From: http://stackoverflow.com/questions/8732401/how-to-figure-out-all-colors-in-a-gradient
+From: https://stackoverflow.com/questions/8732401/how-to-figure-out-all-colors-in-a-gradient
 ***********************************************************************************************/
 
 function makeGradientColor(color1, color2, percent) {
@@ -328,9 +328,9 @@ function makeGradientColor(color1, color2, percent) {
     newColor.r = makeChannel(color1.r, color2.r);
     newColor.g = makeChannel(color1.g, color2.g);
     newColor.b = makeChannel(color1.b, color2.b);
-    newColor.cssColor = "#" + 
-                        makeColorPiece(newColor.r) + 
-                        makeColorPiece(newColor.g) + 
+    newColor.cssColor = "#" +
+                        makeColorPiece(newColor.r) +
+                        makeColorPiece(newColor.g) +
                         makeColorPiece(newColor.b);
     return(newColor);
 }

--- a/static/js/init.js
+++ b/static/js/init.js
@@ -14,7 +14,7 @@ $("#escape").hover(
   }
 );
 $("#escape").on('click', function(){
-  window.location = "http://www.google.com/";
+  window.location = "https://www.google.com";
 });
 
 // Quick Tooltip for Search Form Use
@@ -58,7 +58,7 @@ $(function() {
     $collapsibles.last().nextUntil('footer').last()
       .after('<div class="close-collapsible"><button class="btn">Close</button></div>');
     $collapsibles.addClass('collapsible').nextUntil('h2,footer').addClass('inactive');
-    
+
     $collapsibles.on('click', function() {
       $collapsibles.not(this).removeClass('selected').nextUntil('h2,footer').addClass('inactive');
       $(this).toggleClass('selected');
@@ -73,7 +73,7 @@ $(function() {
       var $section_header = $(this).parent().prevUntil('h2').last().prev();
       $section_header.toggleClass('selected'); // un-select section header
       $(window).scrollTop(last_scrollTop); // scroll to where you were when you expanded this section
-    }); 
+    });
     if (window.location.hash != '') {
       $(window.location.hash).nextUntil('h2,footer').removeClass('inactive');
       $(window.location.hash).toggleClass('selected');
@@ -94,7 +94,7 @@ $(function() {
       }
     }
   });
-  
+
   if (window.location.hash != '') {
     var target = window.location.hash;
     $(target).addClass('hash-scrolled');

--- a/static/js/onrrmap.js
+++ b/static/js/onrrmap.js
@@ -1,11 +1,11 @@
 // var mapdataviz = L.mapbox.map('map', 'mhertzfeld.i8l68af5')
 //     .setView([37.8, -91], 4);
 var map_draw_init = false;
-var statesDrawOrder = ["Alabama","Alaska","Arizona", "Arkansas", "Connecticut", "Delaware","District of Columbia", 
-  "Florida", "Georgia", "Hawaii", "Idaho", "Illinois", "Indiana", "Iowa", "Kansas", "Kentucky", "Louisiana", "Maine", 
-  "Maryland", "Massachusetts", "Michigan", "Minnesota", "Mississippi", "Missouri", "Montana", "Nebraska", 
-  "Oregon","New Hampshire", "New Jersey", "New York","North Carolina", "North Dakota","Ohio", "Oklahoma", 
-  "Pennsylvania", "Rhode Island","South Carolina","South Dakota","Tennessee", "Texas", "Vermont", "Virginia", 
+var statesDrawOrder = ["Alabama","Alaska","Arizona", "Arkansas", "Connecticut", "Delaware","District of Columbia",
+  "Florida", "Georgia", "Hawaii", "Idaho", "Illinois", "Indiana", "Iowa", "Kansas", "Kentucky", "Louisiana", "Maine",
+  "Maryland", "Massachusetts", "Michigan", "Minnesota", "Mississippi", "Missouri", "Montana", "Nebraska",
+  "Oregon","New Hampshire", "New Jersey", "New York","North Carolina", "North Dakota","Ohio", "Oklahoma",
+  "Pennsylvania", "Rhode Island","South Carolina","South Dakota","Tennessee", "Texas", "Vermont", "Virginia",
   "Washington", "West Virginia", "Wisconsin", "Wyoming","Utah","Nevada", "California", "Colorado","New Mexico"];
 var atlanticDrawOrder = [ 'North Atlantic','Mid-Atlantic' ,'South Atlantic','Straights of Florida' ];
 var gomDrawOrder = ['Eastern Gulf of Mexico','Central Gulf of Mexico','Western Gulf of Mexico']
@@ -14,8 +14,8 @@ var gomDrawOrder = ['Eastern Gulf of Mexico','Central Gulf of Mexico','Western G
 var mapdataviz = L.map('map', {
     scrollWheelZoom: false
   }).setView([41.5, -99.5795], 4);
-L.tileLayer('http://a.tile.openstreetmap.org/{z}/{x}/{y}.png', {
-    attribution: 'Tiles Courtesy of <a href="http://www.mapquest.com/" target="_blank">MapQuest</a>',
+L.tileLayer('https://a.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+    attribution: 'Tiles Courtesy of <a href="https://www.mapquest.com/" target="_blank">MapQuest</a>',
     maxZoom: 18,
     subdomains: [1, 2, 3, 4]
   }).addTo(mapdataviz);
@@ -47,7 +47,7 @@ for (var i = 0; i<variables.length; i++)
 }
 $('#map-comodities-pane>a').each(function(i){
   $(this).attr('data-value',variables[i]);
-  
+
   $(this).click(function(){
     selectedCommodity= $(this).attr('data-value');
     setVariable($(this).attr('data-value'));
@@ -127,9 +127,9 @@ $('#map-comodities-pane>a').each(function(i){
               {
                 ranges[variables[n]].min = data.features[i].properties.commodities[variables[n]].revenue
               }
-              
+
           }
-            
+
         }
       }
     }
@@ -138,8 +138,8 @@ $('#map-comodities-pane>a').each(function(i){
   function: setVariable
   This function loops through the layers
   and assigns new colors to each layer
-  based on the value of the currently 
-  selected commodity. 
+  based on the value of the currently
+  selected commodity.
   This function then calls calculateHeights
   to draw the 3d effect.
   ***********************************/
@@ -150,7 +150,7 @@ $('#map-comodities-pane>a').each(function(i){
     {
       var scale = ranges[name];
       dataLayers[i].eachLayer(function(layer) {
-        setLayerColor(layer);  
+        setLayerColor(layer);
       });
     }
     /**********************
@@ -176,7 +176,7 @@ $('#map-comodities-pane>a').each(function(i){
       //setStrokeWeight(layer,'3.0');
       setFillColor(layer,'#D8D8D8')
       var Revenue_String = (function(){
-        var selected; 
+        var selected;
         $('#map-comodities-pane a').each(function(){
           if ($(this).attr('aria-pressed')=='true')
             selected = $(this).attr('data-value');
@@ -185,10 +185,10 @@ $('#map-comodities-pane>a').each(function(i){
         {
           if (layer.feature.properties.commodities[selected])
             var revenueAmt = layer.feature.properties.commodities[selected].revenue;
-          else 
+          else
             var revenueAmt = 0.0;
         }
-        else 
+        else
         {
           var revenueAmt = 0.0;
         }
@@ -224,26 +224,26 @@ $('#map-comodities-pane>a').each(function(i){
   function zoomToFeature(e) {
       mapdataviz.fitBounds(e.target.getBounds());
       $('g[id*="map_stack_sector"]').each(function(){
-        $(this).remove(); 
+        $(this).remove();
       });
       var timeout = setInterval(function(){
         calculateHeights();
         clearTimeout(timeout);
       },1000);
   }
-  
+
 
   /*******************************
   function: calculateHeights
-  Looks at the map and based on color, 
-  draws repeated shapes at an angle to 
+  Looks at the map and based on color,
+  draws repeated shapes at an angle to
   create a 3d effect.
   The new shapes have css set to allow
   mouse events to pass through
   *********************************/
   function calculateHeights(){
     $('g[id*="map_stack_sector"]').each(function(){
-      $(this).remove(); 
+      $(this).remove();
     });
     var count = 0;
     var idCount=0;
@@ -271,7 +271,7 @@ $('#map-comodities-pane>a').each(function(i){
       count = 0;
     });
   }
-  
+
   /**************************************
   Sets function on the zoom control for the map
   Clears the 3d sections, then redraws after a second delay
@@ -279,7 +279,7 @@ $('#map-comodities-pane>a').each(function(i){
   ***************************************/
   $('.leaflet-control-zoom-in, .leaflet-control-zoom-out').click(function(){
     $('g[id*="map_stack_sector"]').each(function(){
-      $(this).remove(); 
+      $(this).remove();
     });
     var timeout = setInterval(function(){
       calculateHeights();
@@ -367,7 +367,7 @@ function setLayerColor(layer){
           value = layer.feature.properties.commodities[name].revenue;
           console.log(value);
         }
-          
+
       }
       console.log(value);
       var percent = (value / scale.max) * 100;
@@ -395,5 +395,5 @@ function setLayerColor(layer){
       }
 }
 
-  
-  
+
+

--- a/static/js/search.js
+++ b/static/js/search.js
@@ -15,14 +15,14 @@ $( document ).ready(function() {
       }
     }
   }​
-  
+
   var query = GetURLParameter('q');
-  
+
   if(query) {
     $("input#q").val(query);
     $("#search-result-list").append('<div class="loading"><span class="glyphicon glyphicon-refresh"></span> Loading</div>');
     $.ajax({
-      url: "//api.data.gov/beckley/v0/resources/notalone/?q=" + query + "&size=200&from=0&api_key=TRuYxi0630m5Y4D3ECUjxzdaVNaShjxq6u68MkGx",
+      url: "https://api.data.gov/beckley/v0/resources/notalone/?q=" + query + "&size=200&from=0&api_key=TRuYxi0630m5Y4D3ECUjxzdaVNaShjxq6u68MkGx",
       cache: false,
       dataType: "json"
     })
@@ -30,9 +30,9 @@ $( document ).ready(function() {
         $(".loading").remove();
         $("#search-form").append('<div class="search-results-total"><span class="search-result-number">' + json.hits.total + '</span> Search Results</div>');
         $.each(json.hits.hits, function(i, hit){
-          
+
         var result_description = hit._source.description;
-          
+
           var tags = '';
           if(hit._source.tags) {
             tags+='<div class="search-result-tags">Tags:<ul>'
@@ -41,7 +41,7 @@ $( document ).ready(function() {
             });
             tags+="</ul></div>"
           }
-          
+
           var content_type = "";
           if(hit._source.content_type == "text/html") {
             content_type = '<span class="glyphicon glyphicon-link"></span> Website';

--- a/static/js/where.js
+++ b/static/js/where.js
@@ -1,76 +1,76 @@
 //Javascript and JSON for 'where does the money go' rollover tree map
 
 //JSON content
-var where_stats_data = { 
-	//More info on click 
-	"statsOffshore" : [ 
-		//Remember that the count starts at zero 
-		//NOTE: img links are currently hard coded to gh pages site -- fix later -- figure out how to make these relative given that Jekyll won't parse JS files and so can't use {{ site.url }} 
-		{ 
-			//Array ID -> 0 
-			"Title" : "U.S. Treasury", 
-			"Content" : "Some offshore revenue goes into the U.S. General Fund, which is the same place that money from individual and corporate income taxes go. The General Fund pays for roughly two-thirds of all federal expenditures, including:", 
-			"Img1" : "<img src=\"http://meiqimichelle.github.io/d3-minihack/assets/img/icon_1397.svg\" alt=\"Dogtags\"><h3>U.S. Military</h3>",
-			"Img2" : "<img src=\"http://meiqimichelle.github.io/d3-minihack/assets/img/icon_13130.svg\" alt=\"Park\"><h3>U.S. Parks</h3>",
-			"Img3" : "<img src=\"http://meiqimichelle.github.io/d3-minihack/assets/img/icon_1567.svg\" alt=\"Book and test tube\"><h3>U.S. Schools</h3>"
-		}, 
-		{ 	
-			//Array ID -> 1 
-			"Title" : "States", 
-			"Content" : "Offshore revenues go to states in several different ways. If the revenues are from leases the 8(g) region, they go straight to states. If they are in the GOMESA region, some of these funds go directly to 'Coastal Political Subdivions' such as counties and parishes. It is up to the county, parish or state to decide how to use the revenues.", 
-			"Img1" : "<img src=\"http://meiqimichelle.github.io/d3-minihack/assets/img/icon_4572.svg\" alt=\"Dogtags\"><h3><a href=\"http\://statistics.onrr.gov/PDF/FAQs.pdf\">Learn about 8(g) &#8594;</a></h3>",
-			"Img2" : "<img src=\"http://meiqimichelle.github.io/d3-minihack/assets/img/icon_8676.svg\" alt=\"Coast\"><h3><a href=\"http\://www.boem.gov/Oil-and-Gas-Energy-Program/Energy-Economics/Revenue-Sharing/Index.aspx\">Learn about GOMESA &#8594;</a></h3>",
-			"Img3" : "<h3></h3>"
-		}, 
-		{ 	
-			//Array ID -> 2
-			"Title" : "Historic Preservation Fund", 
-			"Content" : "The <a href=\"http\://www.nps.gov/history/hpg/\">Historic Preservation Fund</a> helps preserve U.S. historical and archaeological sites and cultural heritage through grants to State and Tribal Historic Preservation Offices. Some examples of activities include:", 
-			"Img1" : "<img src=\"http://meiqimichelle.github.io/d3-minihack/assets/img/icon_1566.svg\" alt=\"City buildings\"><h3><a href=\"http\://www.michiganmodern.org/\">Survey Modernist Architecture, Michigan</a></h3>",
-			"Img2" : "<img src=\"http://meiqimichelle.github.io/d3-minihack/assets/img/icon_10119.svg\" alt=\"Schoolhouse\"><h3><a href=\"http\://ncptt.nps.gov/blog/tribal-heritage-grants/\">Restore Peoria Schoolhouse, Peoria Tribe of Indians, Oklahoma</a></h3>",
-			"Img3" : "<img src=\"http://meiqimichelle.github.io/d3-minihack/assets/img/icon_7038.svg\" alt=\"Video camera\"><h3><a href=\"http\://ncptt.nps.gov/blog/tribal-heritage-grants/\">Document Yup’ik Songs & Dances, Calista Elders Council of Alaska</a></h3>"
+var where_stats_data = {
+	//More info on click
+	"statsOffshore" : [
+		//Remember that the count starts at zero
+		//NOTE: img links are currently hard coded to gh pages site -- fix later -- figure out how to make these relative given that Jekyll won't parse JS files and so can't use {{ site.url }}
+		{
+			//Array ID -> 0
+			"Title" : "U.S. Treasury",
+			"Content" : "Some offshore revenue goes into the U.S. General Fund, which is the same place that money from individual and corporate income taxes go. The General Fund pays for roughly two-thirds of all federal expenditures, including:",
+			"Img1" : "<img src=\"https://meiqimichelle.github.io/d3-minihack/assets/img/icon_1397.svg\" alt=\"Dogtags\"><h3>U.S. Military</h3>",
+			"Img2" : "<img src=\"https://meiqimichelle.github.io/d3-minihack/assets/img/icon_13130.svg\" alt=\"Park\"><h3>U.S. Parks</h3>",
+			"Img3" : "<img src=\"https://meiqimichelle.github.io/d3-minihack/assets/img/icon_1567.svg\" alt=\"Book and test tube\"><h3>U.S. Schools</h3>"
 		},
-		{ 	
+		{
+			//Array ID -> 1
+			"Title" : "States",
+			"Content" : "Offshore revenues go to states in several different ways. If the revenues are from leases the 8(g) region, they go straight to states. If they are in the GOMESA region, some of these funds go directly to 'Coastal Political Subdivions' such as counties and parishes. It is up to the county, parish or state to decide how to use the revenues.",
+			"Img1" : "<img src=\"https://meiqimichelle.github.io/d3-minihack/assets/img/icon_4572.svg\" alt=\"Dogtags\"><h3><a href=\"http\://statistics.onrr.gov/PDF/FAQs.pdf\">Learn about 8(g) &#8594;</a></h3>",
+			"Img2" : "<img src=\"https://meiqimichelle.github.io/d3-minihack/assets/img/icon_8676.svg\" alt=\"Coast\"><h3><a href=\"http\://www.boem.gov/Oil-and-Gas-Energy-Program/Energy-Economics/Revenue-Sharing/Index.aspx\">Learn about GOMESA &#8594;</a></h3>",
+			"Img3" : "<h3></h3>"
+		},
+		{
+			//Array ID -> 2
+			"Title" : "Historic Preservation Fund",
+			"Content" : "The <a href=\"http\://www.nps.gov/history/hpg/\">Historic Preservation Fund</a> helps preserve U.S. historical and archaeological sites and cultural heritage through grants to State and Tribal Historic Preservation Offices. Some examples of activities include:",
+			"Img1" : "<img src=\"https://meiqimichelle.github.io/d3-minihack/assets/img/icon_1566.svg\" alt=\"City buildings\"><h3><a href=\"http\://www.michiganmodern.org/\">Survey Modernist Architecture, Michigan</a></h3>",
+			"Img2" : "<img src=\"https://meiqimichelle.github.io/d3-minihack/assets/img/icon_10119.svg\" alt=\"Schoolhouse\"><h3><a href=\"http\://ncptt.nps.gov/blog/tribal-heritage-grants/\">Restore Peoria Schoolhouse, Peoria Tribe of Indians, Oklahoma</a></h3>",
+			"Img3" : "<img src=\"https://meiqimichelle.github.io/d3-minihack/assets/img/icon_7038.svg\" alt=\"Video camera\"><h3><a href=\"http\://ncptt.nps.gov/blog/tribal-heritage-grants/\">Document Yup’ik Songs & Dances, Calista Elders Council of Alaska</a></h3>"
+		},
+		{
 			//Array ID -> 3
-			"Title" : "Land & Water Conservation Fund", 
-			"Content" : "The <a href=\"http\://www.nps.gov/lwcf/\">Land & Water Conservation Fund</a> program provides matching grants to states and local governments for the acquisition and development of public outdoor recreation areas. </p><p>Here are a few places that were funded by LWCF grants:", 
-			"Img1" : "<img src=\"http://meiqimichelle.github.io/d3-minihack/assets/img/icon_16251.svg\" alt=\"Mountains\"><h3><a href=\"http\://www.emnrd.state.nm.us/SPD/eaglenestlakestatepark.html\">Eagle Nest Lake State Park, New Mexico</a></h3>",
-			"Img2" : "<img src=\"http://meiqimichelle.github.io/d3-minihack/assets/img/icon_26235.svg\" alt=\"Playground\"><h3><a href=\"http\://www.mitchellparkdc.org/history.html\">Mitchell Park, District of Columbia</a></h3>",
-			"Img3" : "<img src=\"http://meiqimichelle.github.io/d3-minihack/assets/img/icon_25079.svg\" alt=\"Baseball field\"><h3><a href=\"http\://www.ofallon.org/parks/pages/family-sports-park\">Family Sports Park, Illinois</a></h3>"
-		}, 
+			"Title" : "Land & Water Conservation Fund",
+			"Content" : "The <a href=\"http\://www.nps.gov/lwcf/\">Land & Water Conservation Fund</a> program provides matching grants to states and local governments for the acquisition and development of public outdoor recreation areas. </p><p>Here are a few places that were funded by LWCF grants:",
+			"Img1" : "<img src=\"https://meiqimichelle.github.io/d3-minihack/assets/img/icon_16251.svg\" alt=\"Mountains\"><h3><a href=\"http\://www.emnrd.state.nm.us/SPD/eaglenestlakestatepark.html\">Eagle Nest Lake State Park, New Mexico</a></h3>",
+			"Img2" : "<img src=\"https://meiqimichelle.github.io/d3-minihack/assets/img/icon_26235.svg\" alt=\"Playground\"><h3><a href=\"http\://www.mitchellparkdc.org/history.html\">Mitchell Park, District of Columbia</a></h3>",
+			"Img3" : "<img src=\"https://meiqimichelle.github.io/d3-minihack/assets/img/icon_25079.svg\" alt=\"Baseball field\"><h3><a href=\"http\://www.ofallon.org/parks/pages/family-sports-park\">Family Sports Park, Illinois</a></h3>"
+		},
 	],
 
-	"statsOnshore" : [ 
-		//Remember that the count starts at zero 
-		//NOTE: img links are currently hard coded to gh pages site -- fix later -- figure out how to make these relative given that Jekyll won't parse JS files and so can't use {{ site.url }} 
-		{ 
-			//Array ID -> 0 
-			"Title" : "States", 
-			"Content" : "The state share of onshore revenues go to two different places. Revenue from geothermal resources goes directly to counties. The rest goes to states. It's up to each county and state to decide how to use the revenue.", 
-			"Img1" : "<img src=\"http://meiqimichelle.github.io/d3-minihack/assets/img/icon_2070.svg\" alt=\"Geothermal energy plant\">", 
+	"statsOnshore" : [
+		//Remember that the count starts at zero
+		//NOTE: img links are currently hard coded to gh pages site -- fix later -- figure out how to make these relative given that Jekyll won't parse JS files and so can't use {{ site.url }}
+		{
+			//Array ID -> 0
+			"Title" : "States",
+			"Content" : "The state share of onshore revenues go to two different places. Revenue from geothermal resources goes directly to counties. The rest goes to states. It's up to each county and state to decide how to use the revenue.",
+			"Img1" : "<img src=\"https://meiqimichelle.github.io/d3-minihack/assets/img/icon_2070.svg\" alt=\"Geothermal energy plant\">",
 			"Img1Cap" : "<h3>Geothermal Energy Revenues</h3><p>...go directly to counties</p>",
-			"Img2" : "<img src=\"http://meiqimichelle.github.io/d3-minihack/assets/img/icon_38222.svg\" alt=\"U.S. States\">", 
+			"Img2" : "<img src=\"https://meiqimichelle.github.io/d3-minihack/assets/img/icon_38222.svg\" alt=\"U.S. States\">",
 			"Img2Cap" : "<h3>Other Resource Revenues</h3><p>...go to states</p>"
-		}, 
-		{ 	
-			//Array ID -> 1 
-			"Title" : "Reclamation Fund", 
-			"Content" : "The Reclamation Fund is a special fund established by the United States Congress under the Reclamation Act of 1902 to pay for Bureau of Reclamation projects. </p><p>What does this help pay for?", 
-			"Img1" : "<img src=\"http://meiqimichelle.github.io/d3-minihack/assets/img/icon_18711.svg\" alt=\"Farm\">",
+		},
+		{
+			//Array ID -> 1
+			"Title" : "Reclamation Fund",
+			"Content" : "The Reclamation Fund is a special fund established by the United States Congress under the Reclamation Act of 1902 to pay for Bureau of Reclamation projects. </p><p>What does this help pay for?",
+			"Img1" : "<img src=\"https://meiqimichelle.github.io/d3-minihack/assets/img/icon_18711.svg\" alt=\"Farm\">",
 			"Img1Cap" : "<h3>Irrigation water</h3><p> for 10 million acres of farmland</p>",
-			"Img2" : "<img src=\"http://meiqimichelle.github.io/d3-minihack/assets/img/icon_265.svg\" alt=\"Dam\">", 
+			"Img2" : "<img src=\"https://meiqimichelle.github.io/d3-minihack/assets/img/icon_265.svg\" alt=\"Dam\">",
 			"Img2Cap" : "<h3>Hydroelectric power</h3><p> for XYZ number of people</p>"
-		}, 
-		{ 	
+		},
+		{
 			//Array ID -> 2
-			"Title" : "U.S. Treasury", 
-			"Content" : "10% of onshore revenue goes into the U.S. General Fund, which is the same place that money from individual and corporate income taxes go. The General Fund pays for roughly two-thirds of all federal expenditures, including:", 
-			"Img1" : "<img src=\"http://meiqimichelle.github.io/d3-minihack/assets/img/icon_1397.svg\" alt=\"Dogtags\">",
+			"Title" : "U.S. Treasury",
+			"Content" : "10% of onshore revenue goes into the U.S. General Fund, which is the same place that money from individual and corporate income taxes go. The General Fund pays for roughly two-thirds of all federal expenditures, including:",
+			"Img1" : "<img src=\"https://meiqimichelle.github.io/d3-minihack/assets/img/icon_1397.svg\" alt=\"Dogtags\">",
 			"Img1Cap" : "<h3>U.S. Military</h3>",
-			"Img2" : "<img src=\"http://meiqimichelle.github.io/d3-minihack/assets/img/icon_13130.svg\" alt=\"Park\">",
+			"Img2" : "<img src=\"https://meiqimichelle.github.io/d3-minihack/assets/img/icon_13130.svg\" alt=\"Park\">",
 			"Img2Cap" : "<h3>U.S. Parks</h3>"
 		},
-	]  
+	]
 }
 
 
@@ -80,7 +80,7 @@ $(document).ready(function() {
 	$('.stats-offshore > div').click(function(){
 
 			//Get the ID of the current click div
-			active_square = $(this).attr('rel'); 
+			active_square = $(this).attr('rel');
 
 			//Replace the HTML in the header with data from JSON array
 			$('#offshore h2').html(where_stats_data.statsOffshore[active_square].Title);
@@ -90,10 +90,10 @@ $(document).ready(function() {
 			$('#payimgs-off div:nth-child(3)').html(where_stats_data.statsOffshore[active_square].Img3);
 
 		})
-	$('.stats-onshore > div').click(function(){  
+	$('.stats-onshore > div').click(function(){
 
 			//Get the ID of the current click div
-			active_square = $(this).attr('rel'); 
+			active_square = $(this).attr('rel');
 
 			//Replace the HTML in the header with data from JSON array
 			$('#onshore h2').html(where_stats_data.statsOnshore[active_square].Title);


### PR DESCRIPTION
The site under HTTPS, https://18f.github.io/doi-extractives-data/ is currently totally broken, with lots of warnings.

This fixes that, mostly by using `site.baseurl` instead of `site.url` wherever possible, and adjusting the URLs to not use trailing slashes for consistency.

I also updated a few other URLs to use `https://`, such as the Open Street Map tile API call.
