### PR TITLE
Feature/improve mobile

### DIFF
--- a/static/_sass/_custom.scss
+++ b/static/_sass/_custom.scss
@@ -2064,9 +2064,15 @@ text.x-axis-label{
 }
 
 .documentation-tabs {
-  @include rem-fallback(font-size, 1);
+  @include rem-fallback(font-size, 0.8);
+  @include respond-to(tiny-up) {
+    @include rem-fallback(font-size, 1);
+  }
   a {
-    padding: 5px 9px 8px 9px;
+    padding: 5px 7px 7px 7px;
+    @include respond-to(tiny-up) {
+      padding: 5px 9px 8px 9px;
+    }
     @include respond-to(small-up) {
       padding: 5px 17px 8px 17px;
     }


### PR DESCRIPTION
- Adds scroll area to side of map
- Fixes 'long commodity' name on commodity toggles on map on mobile sizes
- Adds a bit of space on map notes.
- Fixes data and documentation tabs on data and documentation pages
