### PR TITLE
Adds glossary routine for CY and FY references in downloads

### DIFF
--- a/_downloads/default.md
+++ b/_downloads/default.md
@@ -55,7 +55,7 @@ tag:
     <li class="downloads-download_links">
     <a href="{{site.baseurl}}/downloads/federal-revenue-by-location/" class="link-no_under"><h3 id="federal-revenue-by-location">
     Federal revenue by location</h3></a>
-    <p>Federal revenue from natural resources extracted from federal land and waters by location. This dataset is from the <a href="http://www.onrr.gov/">Office of Natural Resources Revenue</a>, which is part of the Department of the Interior. It is separated into onshore and offshore data, and is available by calendar year (CY) and fiscal year (FY).</p>
+    <p>Federal revenue from natural resources extracted from federal land and waters by location. This dataset is from the <a href="http://www.onrr.gov/">Office of Natural Resources Revenue</a>, which is part of the Department of the Interior. It is separated into onshore and offshore data, and is available by {{ "calendar year (CY)" | term }} and {{ "fiscal year (FY)" | term_end }}.</p>
     <a href="{{site.baseurl}}/downloads/federal-revenue-by-location/">
       <object type="image/svg+xml" data="{{site.baseurl}}/public/img/icons/file-text-o.svg" class="u-padding-right icon-small">
       </object>Data and documentation

--- a/_downloads/federal-revenue-by-location.md
+++ b/_downloads/federal-revenue-by-location.md
@@ -46,7 +46,7 @@ tag:
 - By location
 ---
 
-> There are three types of federal-revenue-by-location datasets available on this site. One includes offshore data, another includes onshore data, and the third has data on revenues that aren't associated with a specific location. We have versions of these datasets available for calendar and fiscal years 2006 through 2017. They are all accounting year data.
+> There are three types of federal-revenue-by-location datasets available on this site. One includes offshore data, another includes onshore data, and the third has data on revenues that aren't associated with a specific location. We have versions of these datasets available for calendar and fiscal years 2006 through 2017. They are all {{ "accounting year" | term }} data.
 
 Download calendar year data:
 


### PR DESCRIPTION
[:sunglasses: PREVIEW](https://federalist-proxy.app.cloud.gov/preview/18f/doi-extractives-data/glossarize/downloads/)

Changes proposed in this pull request:

- Adds glossary references for calendar year, fiscal year, and accounting year in [Data and documentation](https://federalist-proxy.app.cloud.gov/preview/18f/doi-extractives-data/glossarize/downloads/) and [Federal revenue by location](https://federalist-proxy.app.cloud.gov/preview/18f/doi-extractives-data/glossarize/downloads/federal-revenue-by-location/).

